### PR TITLE
fix: p_remain_rates AttributeError

### DIFF
--- a/jenga_hyvideo.py
+++ b/jenga_hyvideo.py
@@ -282,7 +282,7 @@ def main():
         hunyuan_video_sampler.pipeline.transformer.__class__.curve_sel = None
         hunyuan_video_sampler.pipeline.transformer.__class__.sa_drop_rates = args.sa_drop_rates
         hunyuan_video_sampler.pipeline.transformer.__class__.scale_txt_amp = args.scale_txt_amp
-        hunyuan_video_sampler.pipeline.transformer.__class__.enable_skip = args.p_remain_rates
+        hunyuan_video_sampler.pipeline.transformer.__class__.p_remain_rates = args.p_remain_rates
 
         # Start sampling
         outputs = hunyuan_video_sampler.predict(


### PR DESCRIPTION
When I executed this code, I found that p_remain_rates was patched into the wrong field, resulting in an AttributeError.
The following is the error log at that time:
```
Traceback (most recent call last):
  File "./jenga_hyvideo.py", line 321, in <module>
    main()
  File "./jenga_hyvideo.py", line 290, in main
    outputs = hunyuan_video_sampler.predict(
  File "/usr/local/python/lib/python3.8/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/my_workspace/Jenga/hyvideo/inference.py", line 549, in predict
    samples = self.pipeline(
  File "/usr/local/python/lib/python3.8/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/my_workspace/Jenga/hyvideo/diffusion/pipelines/pipeline_hunyuan_video_prores.py", line 667, in __call__
    noise_pred = self.transformer(  # For an input image (129, 192, 336) (1, 256, 256)
  File "/usr/local/python/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/usr/local/python/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "./jenga_hyvideo.py", line 154, in ra_forward
    self.p_remain_rates,
  File "/usr/local/python/lib/python3.8/site-packages/diffusers/models/modeling_utils.py", line 151, in __getattr__
    return super().__getattr__(name)
  File "/usr/local/python/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1695, in __getattr__
    raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
AttributeError: 'HYVideoDiffusionTransformer' object has no attribute 'p_remain_rates'
```