### PR TITLE
chore: The generated video size needs to meet the constraints.

### DIFF
--- a/jenga_hyi2v.py
+++ b/jenga_hyi2v.py
@@ -40,6 +40,8 @@ def build_multi_curve(latent_time, latent_height, latent_width, res_rate_list,
         latent_time_ = int(latent_time)
         latent_height_ = int(latent_height * res_rate)
         latent_width_ = int(latent_width * res_rate)
+        if (latent_height_ * latent_width_) % 4 != 0:
+            raise ValueError(f"latent_height_ * latent_width_ must be divisible by 4, but got {latent_height_ * latent_width_}")
         LINEAR_TO_HILBERT, HILBERT_ORDER = gilbert_mapping(latent_time_, latent_height_, latent_width_)
         block_neighbor_list = gilbert_block_neighbor_mapping(latent_time_, latent_height_, latent_width_)
         curve_sel.append([torch.tensor(LINEAR_TO_HILBERT, dtype=torch.long), torch.tensor(HILBERT_ORDER, dtype=torch.long), block_neighbor_list])

--- a/jenga_hyvideo.py
+++ b/jenga_hyvideo.py
@@ -48,6 +48,8 @@ def build_multi_curve(latent_time, latent_height, latent_width, res_rate_list):
         latent_time_ = int(latent_time)
         latent_height_ = int(latent_height * res_rate)
         latent_width_ = int(latent_width * res_rate)
+        if (latent_height_ * latent_width_) % 4 != 0:
+            raise ValueError(f"latent_height_ * latent_width_ must be divisible by 4, but got {latent_height_ * latent_width_}")
         LINEAR_TO_HILBERT, HILBERT_ORDER = gilbert_mapping(latent_time_, latent_height_, latent_width_)
         block_neighbor_list = gilbert_block_neighbor_mapping(latent_time_, latent_height_, latent_width_)
         curve_sel.append([torch.tensor(LINEAR_TO_HILBERT, dtype=torch.long), torch.tensor(HILBERT_ORDER, dtype=torch.long), block_neighbor_list])

--- a/jenga_hyvideo_multigpu.py
+++ b/jenga_hyvideo_multigpu.py
@@ -92,6 +92,8 @@ def build_multi_curve(latent_time, latent_height, latent_width, res_rate_list):
         latent_time_ = int(latent_time)
         latent_height_ = int(latent_height * res_rate)
         latent_width_ = int(latent_width * res_rate)
+        if (latent_height_ * latent_width_) % 4 != 0:
+            raise ValueError(f"latent_height_ * latent_width_ must be divisible by 4, but got {latent_height_ * latent_width_}")
         LINEAR_TO_HILBERT, HILBERT_ORDER = gilbert_mapping(latent_time_, latent_height_, latent_width_)
         block_neighbor_list = gilbert_block_neighbor_mapping(latent_time_, latent_height_, latent_width_)
         curve_sel.append([torch.tensor(LINEAR_TO_HILBERT, dtype=torch.long), torch.tensor(HILBERT_ORDER, dtype=torch.long), block_neighbor_list])


### PR DESCRIPTION
When I tried to generate videos with different resolutions, I found that the resolution of the generated videos must satisfy the constraint that `int((height // 16) * res_rate) * int((width // 16) * res_rate) % 4 == 0`. Therefore, I added this piece of logic to return an error message in advance before the model is loaded.