### PR TITLE
fix: width and height bug

### DIFF
--- a/jenga_wan.py
+++ b/jenga_wan.py
@@ -1011,7 +1011,7 @@ def generate(args):
         wan_t2v.model.__class__.enable_teacache = True
         wan_t2v.model.__class__.forward = teacache_forward
         # JULIAN: space curve related.
-        pixel_h, pixel_w = SIZE_CONFIGS[args.size]
+        pixel_w, pixel_h = SIZE_CONFIGS[args.size]
         latent_time = (args.frame_num + 3) // 4
         latent_height = pixel_h // 16
         latent_width = pixel_w // 16


### PR DESCRIPTION
`SIZE_CONFIGS[args.size]` is `width * height`, so we should use 
`pixel_w, pixel_h = SIZE_CONFIGS[args.size]` rather than 
`pixel_h, pixel_w = SIZE_CONFIGS[args.size]`